### PR TITLE
Fix some stability and compatibility problems

### DIFF
--- a/src/url-to-image.js
+++ b/src/url-to-image.js
@@ -138,11 +138,9 @@ function renderPage(opts) {
 
     function renderAndExit() {
         log('Render screenshot..');
-        var pageToRender = page;
-        page.close(); //close the page so no more requests come in.
         if (opts.cropWidth && opts.cropHeight) {
             log("Cropping...");
-            pageToRender.clipRect = {
+            page.clipRect = {
                 top: opts.cropOffsetTop,
                 left: opts.cropOffsetLeft,
                 width: opts.cropWidth,
@@ -160,8 +158,8 @@ function renderPage(opts) {
             renderOpts.format = opts.fileType;
         }
 
-        pageToRender.render(opts.filePath, renderOpts);
-        pageToRender.close();
+        page.render(opts.filePath, renderOpts);
+        page.close();
         log('done.');
         exit();
     }

--- a/src/url-to-image.js
+++ b/src/url-to-image.js
@@ -153,9 +153,15 @@ function renderPage(opts) {
             format:'png'
         };
 
+        var oldOpts = {
+            fileQuality: opts.fileQuality,
+            fileType: 'png',
+        };
+
         if (opts.fileType) {
             log("Adjusting File Type...");
             renderOpts.format = opts.fileType;
+            oldOpts.fileType = opts.fileType;
         }
 
         var count = 0;
@@ -165,7 +171,7 @@ function renderPage(opts) {
                 exit(1);
             }
 
-            if (page.render(opts.filePath, renderOpts)) {
+            if (page.render(opts.filePath, renderOpts) || page.render(opts.filePath, oldOpts)) {
                 page.close();
                 log('done.');
                 exit();

--- a/src/url-to-image.js
+++ b/src/url-to-image.js
@@ -158,10 +158,21 @@ function renderPage(opts) {
             renderOpts.format = opts.fileType;
         }
 
-        page.render(opts.filePath, renderOpts);
-        page.close();
-        log('done.');
-        exit();
+        var count = 0;
+        setInterval(function () {
+            if (count > opts.maxTimeout / opts.requestTimeout) {
+                log('timeout.');
+                exit(1);
+            }
+
+            if (page.render(opts.filePath, renderOpts)) {
+                page.close();
+                log('done.');
+                exit();
+            }
+
+            count++;
+        }, opts.requestTimeout);
     }
 }
 //custom exit function


### PR DESCRIPTION
This adds a retry to failed page.render() calls in requestTimeout intervals, up to maxTimeout. If maxTimeout is hit, an error is returned that can be hadled in a .catch(). This approach was inspired by https://github.com/ariya/phantomjs/issues/11995, which I was also hitting.

This also re-introduces the old phantomjs options as a fallback for compatibility.
